### PR TITLE
testing dot product for potential bug and changed std::__bit_width to std::bit_width

### DIFF
--- a/bsi/BsiVector.hpp
+++ b/bsi/BsiVector.hpp
@@ -18,6 +18,7 @@
 #include <bitset>
 #include <algorithm>
 #include <thread>
+#include <bit>
 
 
 template <class uword = uint64_t> class BsiUnsigned;
@@ -465,7 +466,8 @@ BsiVector<uword>* BsiVector<uword>::buildBsiVector(std::vector<long> nums, doubl
         min = std::min(min, nums[count]);
     }
 
-    int slices =  std::__bit_width(std::max(std::abs(min), std::abs(max)));
+    int slices =  std::bit_width(static_cast<unsigned long>(std::max(std::abs(min), std::abs(max))));
+    std::cout << "Slices: " << slices << std::endl;
 
     if (min < 0) {
         BsiVector<uword>* res = new BsiSigned<uword>(slices+2);
@@ -591,7 +593,7 @@ BsiVector<uword>* BsiVector<uword>::buildBsiVector(std::vector<double> nums, int
         min = std::min(min,  nums_long[it]);
     }
 
-    int slices =  std::__bit_width(std::max(std::abs(min), std::abs(max)));
+    int slices =  std::bit_width(static_cast<unsigned long>(std::max(std::abs(min), std::abs(max))));
 
     if (min < 0) {
         BsiVector<uword>* res = new BsiSigned<uword>(slices+1);

--- a/examples/add_benchmark.cpp
+++ b/examples/add_benchmark.cpp
@@ -1,0 +1,255 @@
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <vector>
+#include <cstdint>
+using uint128_t = unsigned __int128;
+
+#include "../bsi/BsiUnsigned.hpp"
+#include "../bsi/BsiSigned.hpp"
+#include "../bsi/BsiVector.hpp"
+
+struct RangeInfo {
+    std::size_t rangeMax;      
+    int         expectedBits;  
+    const char *label;
+};
+
+int main() {
+    std::srand(static_cast<unsigned>(std::time(nullptr)));
+
+    constexpr std::size_t vectorLength = 10'000'000;   // 10 M rows
+    std::vector<RangeInfo> ranges = {
+        {101,       7,  "0-100"},
+        {1001,      10, "0-1000"},
+        {1u << 16,  16, "0-65535"}
+    };
+
+    auto MB = [](double bytes) { return bytes / (1024.0 * 1024.0); };
+
+    for (const auto &cfg : ranges) {
+        std::cout << "\n================ Benchmark for range "
+                  << cfg.label << " ================\n";
+
+        std::vector<long> data(vectorLength);
+        for (std::size_t i = 0; i < vectorLength; ++i)
+            data[i] = std::rand() % cfg.rangeMax;
+
+        long plainSum = 0;
+        auto tAdd0 = std::chrono::high_resolution_clock::now();
+        for (std::size_t i = 0; i < vectorLength; ++i)
+            plainSum += data[i];
+        auto tAdd1 = std::chrono::high_resolution_clock::now();
+
+        auto durPlain = std::chrono::duration_cast<
+                            std::chrono::microseconds>(tAdd1 - tAdd0).count();
+
+        std::size_t element_size  = sizeof(data[0]);          // 8 bytes
+        std::size_t data_size     = data.size()     * element_size;
+        std::size_t capacity_size = data.capacity() * element_size;
+
+        std::size_t maxVal = *std::max_element(data.begin(), data.end());
+        int bitsNeeded = 0;
+        for (auto tmp = maxVal; tmp; tmp >>= 1) ++bitsNeeded;
+
+        BsiUnsigned<uint128_t> ubsi;
+        auto tBuild0 = std::chrono::high_resolution_clock::now();
+        auto *bsi = ubsi.buildBsiVector(data, 0.2);
+        auto tBuild1 = std::chrono::high_resolution_clock::now();
+        bsi->setPartitionID(0);
+        bsi->setFirstSliceFlag(true);
+        bsi->setLastSliceFlag(true);    
+
+        auto tSum0 = std::chrono::high_resolution_clock::now();
+        long bsiSum = bsi->sumOfBsi();
+        auto tSum1 = std::chrono::high_resolution_clock::now();
+
+        auto durBuild  = std::chrono::duration_cast<
+                            std::chrono::microseconds>(tBuild1 - tBuild0).count();
+        auto durBsiSum = std::chrono::duration_cast<
+                            std::chrono::microseconds>(tSum1 - tSum0).count();
+
+        std::cout << "Element size: " << element_size
+                  << " bytes (" << element_size * 8 << " bits)\n";
+
+        std::cout << "Vector sum = " << plainSum
+                  << " | time = " << durPlain << " µs"
+                  << " | data mem ≈ " << std::fixed << std::setprecision(2)
+                  << MB(data_size) << " MB"
+                  << " | alloc mem ≈ " << MB(capacity_size) << " MB\n";
+
+        std::cout << "BSI   sum = " << bsiSum
+                  << " | build = " << durBuild << " µs"
+                  << " | sum = " << durBsiSum << " µs"
+                  << " | mem ≈ " << MB(bsi->getSizeInMemory()) << " MB\n";
+
+        std::cout << "Expected bits: " << cfg.expectedBits
+                  << " | bits needed by data: " << bitsNeeded
+                  << " | BSI slices: " << bsi->getNumberOfSlices() << "\n";
+
+        if (plainSum != bsiSum)
+            std::cerr << "[WARNING] mismatch between plain and BSI sums!\n";
+
+        delete bsi;
+    }
+    return 0;
+}
+
+
+/*
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <vector>
+#include <cstdint>
+using uint128_t = unsigned __int128;
+
+#include "../bsi/BsiUnsigned.hpp"
+#include "../bsi/BsiSigned.hpp"
+#include "../bsi/BsiVector.hpp"
+
+struct RangeInfo {
+    std::size_t rangeMax;      
+    int         expectedBits; 
+    const char *label;
+};
+
+int main() {
+    constexpr std::size_t vectorLength = 10'000'000;              
+    std::vector<RangeInfo> ranges = {
+        {101,       7,  "0-100"},
+        {1001,      10, "0-1000"},
+        {1u << 16,  16, "0-65535"}
+    };
+
+    auto MB = [](double bytes) { return bytes / (1024.0 * 1024.0); };
+
+    for (const auto &cfg : ranges) {
+        std::cout << "\n================ Benchmark for range "
+                  << cfg.label << " ================\n";
+
+        std::size_t plainMemBytes = 0;          
+        long        plainSum      = 0;          
+        std::size_t maxVal        = 0;          
+
+        std::vector<long> dataForBsi;           
+        dataForBsi.reserve(vectorLength);
+
+        if (cfg.rangeMax <= 0x101) {
+            std::vector<std::uint8_t> data8(vectorLength);
+            for (std::size_t i = 0; i < vectorLength; ++i)
+                data8[i] = std::rand() % cfg.rangeMax;
+            auto t0 = std::chrono::high_resolution_clock::now();
+            for (std::size_t i = 0; i < vectorLength; ++i)
+                plainSum += data8[i];
+            auto t1 = std::chrono::high_resolution_clock::now();
+            auto durPlain = std::chrono::duration_cast<
+                                std::chrono::microseconds>(t1 - t0).count();
+
+            dataForBsi.assign(data8.begin(), data8.end());
+            maxVal = *std::max_element(data8.begin(), data8.end());
+            plainMemBytes = vectorLength * sizeof(std::uint8_t);
+
+            BsiUnsigned<uint128_t> ubsi;
+            auto tBuild0 = std::chrono::high_resolution_clock::now();
+            auto *bsi = ubsi.buildBsiVector(dataForBsi, 0.0);
+            auto tBuild1 = std::chrono::high_resolution_clock::now();
+
+            auto tSum0 = std::chrono::high_resolution_clock::now();
+            long bsiSum = bsi->sumOfBsi();
+            auto tSum1 = std::chrono::high_resolution_clock::now();
+
+            auto durBuild  = std::chrono::duration_cast<
+                                std::chrono::microseconds>(tBuild1 - tBuild0).count();
+            auto durBsiSum = std::chrono::duration_cast<
+                                std::chrono::microseconds>(tSum1 - tSum0).count();
+
+            int bitsNeeded = 0;
+            for (auto tmp = maxVal; tmp; tmp >>= 1) ++bitsNeeded;
+
+            std::cout << "Vector sum = " << plainSum
+                      << " | time = " << durPlain << " µs"
+                      << " | mem ≈ " << std::fixed << std::setprecision(2)
+                      << MB(plainMemBytes) << " MB\n";
+
+            std::cout << "BSI   sum = " << bsiSum
+                      << " | build = " << durBuild << " µs"
+                      << " | sum = " << durBsiSum << " µs"
+                      << " | mem ≈ " << MB(bsi->getSizeInMemory()) << " MB\n";
+
+            std::cout << "Expected bits: " << cfg.expectedBits
+                      << " | bits needed by data: " << bitsNeeded
+                      << " | BSI slices: " << bsi->getNumberOfSlices() << "\n";
+
+            if (plainSum != bsiSum)
+                std::cerr << "Mismatch between plain and BSI sums!\n";
+
+            delete bsi;                                  
+        }
+        else {
+            std::vector<std::uint16_t> data16(vectorLength);
+            for (std::size_t i = 0; i < vectorLength; ++i)
+                data16[i] = std::rand() % cfg.rangeMax;
+
+            auto t0 = std::chrono::high_resolution_clock::now();
+            for (std::size_t i = 0; i < vectorLength; ++i)
+                plainSum += data16[i];
+            auto t1 = std::chrono::high_resolution_clock::now();
+            auto durPlain = std::chrono::duration_cast<
+                                std::chrono::microseconds>(t1 - t0).count();
+
+            dataForBsi.assign(data16.begin(), data16.end());
+            maxVal = *std::max_element(data16.begin(), data16.end());
+            plainMemBytes = vectorLength * sizeof(std::uint16_t);
+
+            BsiUnsigned<uint128_t> ubsi;
+            auto tBuild0 = std::chrono::high_resolution_clock::now();
+            auto *bsi = ubsi.buildBsiVector(dataForBsi, 0.0);
+            auto tBuild1 = std::chrono::high_resolution_clock::now();
+
+            bsi->setPartitionID(0);
+            bsi->setFirstSliceFlag(true);
+            bsi->setLastSliceFlag(true);
+
+            auto tSum0 = std::chrono::high_resolution_clock::now();
+            long bsiSum = bsi->sumOfBsi();
+            auto tSum1 = std::chrono::high_resolution_clock::now();
+
+            auto durBuild  = std::chrono::duration_cast<
+                                std::chrono::microseconds>(tBuild1 - tBuild0).count();
+            auto durBsiSum = std::chrono::duration_cast<
+                                std::chrono::microseconds>(tSum1 - tSum0).count();
+
+            int bitsNeeded = 0;
+            for (auto tmp = maxVal; tmp; tmp >>= 1) ++bitsNeeded;
+
+            std::cout << "Vector sum = " << plainSum
+                      << " | time = " << durPlain << " µs"
+                      << " | mem ≈ " << std::fixed << std::setprecision(2)
+                      << MB(plainMemBytes) << " MB\n";
+
+            std::cout << "BSI   sum = " << bsiSum
+                      << " | build = " << durBuild << " µs"
+                      << " | sum = " << durBsiSum << " µs"
+                      << " | mem ≈ " << MB(bsi->getSizeInMemory()) << " MB\n";
+
+            std::cout << "Expected bits: " << cfg.expectedBits
+                      << " | bits needed by data: " << bitsNeeded
+                      << " | BSI slices: " << bsi->getNumberOfSlices() << "\n";
+
+            if (plainSum != bsiSum)
+                std::cerr << "Mismatch between plain and BSI sums!\n";
+
+            delete bsi;
+        }
+    }
+    return 0;
+}
+*/

--- a/examples/dot_test_unsigned.cpp
+++ b/examples/dot_test_unsigned.cpp
@@ -1,0 +1,93 @@
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <vector>
+#include <cstdint>
+using uint128_t = unsigned __int128;
+
+#include "../bsi/BsiUnsigned.hpp"
+#include "../bsi/BsiSigned.hpp"
+#include "../bsi/BsiVector.hpp"
+
+struct RangeInfo {
+    std::size_t rangeMax;
+    int         expectedBits;
+    const char* label;
+};
+
+int main() {
+    std::srand(static_cast<unsigned>(std::time(nullptr)));
+    constexpr std::size_t N = 10'000'000;
+    std::vector<RangeInfo> ranges = {
+        {101,      7,  "0-100"},
+        {1001,     10, "0-1000"},
+        {1u<<16,   16, "0-65535"}
+    };
+
+    auto MB = [](double bytes){ return bytes / (1024.0*1024.0); };
+
+    for (auto& cfg : ranges) {
+        std::cout << "\n=== Benchmark range " << cfg.label << " ===\n";
+
+        std::vector<long> A(N), B(N);
+        for (std::size_t i = 0; i < N; ++i) {
+            A[i] = std::rand() % cfg.rangeMax;
+            B[i] = std::rand() % cfg.rangeMax;
+        }
+
+        long plainDot = 0;
+        auto t0 = std::chrono::high_resolution_clock::now();
+        for (std::size_t i = 0; i < N; ++i)
+            plainDot += A[i]*B[i];
+        auto t1 = std::chrono::high_resolution_clock::now();
+        auto durPlain = std::chrono::duration_cast<std::chrono::microseconds>(t1-t0).count();
+
+        size_t eSz = sizeof(A[0]);
+        size_t usedA = A.size()*eSz, allocA = A.capacity()*eSz;
+        size_t usedB = B.size()*eSz, allocB = B.capacity()*eSz;
+        BsiUnsigned<uint128_t> ubsi;
+        auto tb0 = std::chrono::high_resolution_clock::now();
+        auto *bA = ubsi.buildBsiVector(A, 0.2);
+        auto *bB = ubsi.buildBsiVector(B, 0.2);
+        bA->setPartitionID(0); bA->setFirstSliceFlag(true); bA->setLastSliceFlag(true);
+        bB->setPartitionID(0); bB->setFirstSliceFlag(true); bB->setLastSliceFlag(true);
+        auto tb1 = std::chrono::high_resolution_clock::now();
+        auto durBuild = std::chrono::duration_cast<std::chrono::microseconds>(tb1-tb0).count();
+
+        auto td0 = std::chrono::high_resolution_clock::now();
+        long bsiDot = bA->dot(bB);
+        auto td1 = std::chrono::high_resolution_clock::now();
+        auto durDot = std::chrono::duration_cast<std::chrono::microseconds>(td1-td0).count();
+
+        long maxA = *std::max_element(A.begin(), A.end());
+        int bitsNeeded = 0; for (auto v=maxA; v; v>>=1) ++bitsNeeded;
+
+        std::cout << "Plain dot = " << plainDot
+                  << " | time = " << durPlain << " µs\n"
+                  << "  A mem used/alloc = " << std::fixed<<std::setprecision(2)
+                  << MB(usedA) << "/"<< MB(allocA)<<" MB\n"
+                  << "  B mem used/alloc = " << MB(usedB) << "/"<< MB(allocB)<<" MB\n";
+
+        std::cout << "BSI dot = " << bsiDot
+                  << " | build = " << durBuild << " µs"
+                  << " | dot = "   << durDot   << " µs\n"
+                  << "  BSI A mem = " << MB(bA->getSizeInMemory())
+                  << " MB | BSI B mem = " << MB(bB->getSizeInMemory()) << " MB\n";
+
+        std::cout << "Expected bits=" << cfg.expectedBits
+                  << " | bitsNeeded=" << bitsNeeded
+                  << " | slices A="<< bA->getNumberOfSlices()
+                  << " | slices B="<< bB->getNumberOfSlices() << "\n";
+
+        if (plainDot != bsiDot)
+            std::cerr<<"[WARN] mismatch plain vs BSI dot\n";
+
+        delete bA; delete bB;
+    }
+
+    return 0;
+}

--- a/examples/example_corrected.cpp
+++ b/examples/example_corrected.cpp
@@ -10,7 +10,7 @@
 #include <iomanip>
 #include <chrono>
 #include <random>
-#include <omp.h>
+// #include <omp.h>
 
 #include "../bsi/BsiUnsigned.hpp"
 #include "../bsi/BsiSigned.hpp"
@@ -93,11 +93,11 @@ int main(){
 
     std::chrono::high_resolution_clock::time_point t10 = std::chrono::high_resolution_clock::now();
 
-    bsi_1 = ubsi.buildBsiVectorFromVector(array1, 0);
+    bsi_1 = ubsi.buildBsiVector(array1, 0);
     bsi_1->setPartitionID(0);
     bsi_1->setFirstSliceFlag(true);
     bsi_1->setLastSliceFlag(true);
-    bsi_2 = ubsi.buildBsiVectorFromVector(array2, 0);
+    bsi_2 = ubsi.buildBsiVector(array2, 0);
     bsi_2->setPartitionID(0);
     bsi_2->setFirstSliceFlag(true);
     bsi_2->setLastSliceFlag(true);


### PR DESCRIPTION
Added a sample test code for dot and we are using uint128_t in this test script. This is different from example_5 where we are using zipf distribution. But the data in this is a random numbers with in the given ranges. 

- the range is defined is a struct and we are testing over different ranges. The values are coming out as expected. 